### PR TITLE
Default to URL for LI

### DIFF
--- a/runner-li.R
+++ b/runner-li.R
@@ -29,8 +29,8 @@ if (
 ) {
   li_credit <- stringr::str_replace(
     metadata$credit$linkedin,
-    "https://www.linkedin.com/in/",
-    "^@"
+    "^@",
+    "https://www.linkedin.com/in/"
   )
   
   credit <- glue::glue(


### PR DESCRIPTION
This inserts the LI mention as a link instead of an `@`. LinkedIn replaces it with a shortened URL, so this isn't perfect yet, but at least it isn't broken! @lgibson7 this will run next week, sorry for forgetting to get it in place sooner!